### PR TITLE
Add UpdateCli initial support for helmfile and sops

### DIFF
--- a/cst.yml
+++ b/cst.yml
@@ -9,15 +9,15 @@ metadataTest:
     - key: io.jenkins-infra.tools
       value: "helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator"
     - key: io.jenkins-infra.tools.helm.version
-      value: "v3.2.1"
+      value: "3.2.1"
     - key: io.jenkins-infra.tools.helmfile.version
       value: "0.116.0"
     - key: "io.jenkins-infra.tools.helm.plugins"
       value: "helm-diff,helm-git,helm-secrets"
     - key: io.jenkins-infra.tools.kubectl.version
-      value: "v1.15.12"
+      value: "1.15.12"
     - key: io.jenkins-infra.tools.sops.version
-      value: "v3.5.0"
+      value: "3.5.0"
     - key: io.jenkins-infra.tools.aws-cli.version
       value: "1.18"
     - key: io.jenkins-infra.tools.aws-iam-authenticator.version

--- a/updateCli/updateCli.d/helmfile.tpl
+++ b/updateCli/updateCli.d/helmfile.tpl
@@ -1,0 +1,45 @@
+---
+source:
+  kind: githubRelease
+  name: Get the latest helmfile version
+  transformers:
+    - trimPrefix: "v"
+  spec:
+    owner: "roboll"
+    repository: "helmfile"
+    token: "{{ requiredEnv .github.token }}"
+    username: "{{ .github.username }}"
+    version: "latest"
+conditions:
+  dockerfileArgHelmfileVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is HELMFILE_VERSION?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "HELMFILE_VERSION"
+targets:
+  updateCstHelmfileVersion:
+    name: "Update the value of HELMFILE_VERSION in the test harness"
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[2].value"
+  updateDockerfileArgHelmfileVersion:
+    name: "Update the value of ARG HELMFILE_VERSION in the Dockerfile"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "HELMFILE_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/updateCli.d/sops.tpl
+++ b/updateCli/updateCli.d/sops.tpl
@@ -1,0 +1,45 @@
+---
+source:
+  kind: githubRelease
+  name: Get the latest SOPS version
+  transformers:
+    - trimPrefix: "v"
+  spec:
+    owner: "mozilla"
+    repository: "sops"
+    token: "{{ requiredEnv .github.token }}"
+    username: "{{ .github.username }}"
+    version: "latest"
+conditions:
+  dockerfileArgSopsVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is SOPS_VERSION?"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "SOPS_VERSION"
+targets:
+  updateCstSopsVersion:
+    name: "Update the value of SOPS_VERSION in the test harness"
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[5].value"
+  updateDockerfileArgSopsVersion:
+    name: "Update the value of ARG SOPS_VERSION in the Dockerfile"
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "SOPS_VERSION"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updateCli/values.yaml
+++ b/updateCli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "updatebot"
+  email: "updatebot@olblak.com"
+  username: "jenkins-infra-bot"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  owner: "jenkins-infra"
+  repository: "docker-helmfile"


### PR DESCRIPTION
Expected to be run manually at first (because it requires that the pipeline-library should be scripted pipeline)

The end-user value is to provide a new version of this image with an up-to-date helmfile for performance reasons, and sops for security reasons after this PR is merged
