### PR TITLE
Updatecli: fix sops and helmfile configurations

### DIFF
--- a/updateCli/updateCli.d/helmfile.tpl
+++ b/updateCli/updateCli.d/helmfile.tpl
@@ -1,4 +1,5 @@
 ---
+title: "[helmfile] Update version"
 source:
   kind: githubRelease
   name: Get the latest helmfile version
@@ -26,6 +27,15 @@ targets:
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[2].value"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
   updateDockerfileArgHelmfileVersion:
     name: "Update the value of ARG HELMFILE_VERSION in the Dockerfile"
     kind: dockerfile

--- a/updateCli/updateCli.d/sops.tpl
+++ b/updateCli/updateCli.d/sops.tpl
@@ -1,4 +1,5 @@
 ---
+title: "[sops] Update version"
 source:
   kind: githubRelease
   name: Get the latest SOPS version
@@ -26,6 +27,15 @@ targets:
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[5].value"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
   updateDockerfileArgSopsVersion:
     name: "Update the value of ARG SOPS_VERSION in the Dockerfile"
     kind: dockerfile


### PR DESCRIPTION
This PR fixes the updatecli configuration.

Validation is done by the PR #8  and PR #9 which prove the the command `updatecli apply --config ./updateCli/updateCli.d --values ./updateCli/values.yaml` works as expected.