### PR TITLE
fix(Dockerfile): replace deprecated helm plugin secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ WORKDIR /home/helm
 
 RUN \
   helm plugin install https://github.com/databus23/helm-diff && \
-  helm plugin install helm plugin install https://github.com/jkroepke/helm-secrets --version v3.9.1 && \
+  helm plugin install https://github.com/jkroepke/helm-secrets --version v3.9.1 && \
   helm plugin install https://github.com/aslafy-z/helm-git.git
 
 LABEL io.jenkins-infra.tools="helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator"

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ WORKDIR /home/helm
 
 RUN \
   helm plugin install https://github.com/databus23/helm-diff && \
-  helm plugin install https://github.com/futuresimple/helm-secrets && \
+  helm plugin install helm plugin install https://github.com/jkroepke/helm-secrets --version v3.9.1 && \
   helm plugin install https://github.com/aslafy-z/helm-git.git
 
 LABEL io.jenkins-infra.tools="helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator"


### PR DESCRIPTION
The previous repository https://github.com/futuresimple/helm-secrets redirects to https://github.com/zendesk/helm-secrets, which is deprecated in favor of https://github.com/jkroepke/helm-secrets