### PR TITLE
fix: use jnlp inbound-agent image as source, bump aws-cli version and add yamllint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN wget "https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSI
 # Please note that only aws cli v1 is supported on alpine - https://github.com/aws/aws-cli/issues/4685
 ARG AWS_CLI_VERSION=1.19
 ARG YAMLLINT_VERSION=1.26
-ARG UPDATECLI_VERSION=v0.16.1
+ARG UPDATECLI_VERSION=v0.17.2
 # hadolint ignore=DL3018
 RUN apk add --no-cache aws-cli=~"${AWS_CLI_VERSION}" yamllint=~"${YAMLLINT_VERSION}" less groff \
   && aws --version | grep -q "${AWS_CLI_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN wget "https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSI
 # Please note that only aws cli v1 is supported on alpine - https://github.com/aws/aws-cli/issues/4685
 ARG AWS_CLI_VERSION=1.19
 ARG YAMLLINT_VERSION=1.26
-ARG UPDATECLI_VERSION=v0.17.2
+ARG UPDATECLI_VERSION=v0.16.1
 # hadolint ignore=DL3018
 RUN apk add --no-cache aws-cli=~"${AWS_CLI_VERSION}" yamllint=~"${YAMLLINT_VERSION}" less groff \
   && aws --version | grep -q "${AWS_CLI_VERSION}"
@@ -64,7 +64,7 @@ RUN \
   helm plugin install https://github.com/jkroepke/helm-secrets --version v3.9.1 && \
   helm plugin install https://github.com/aslafy-z/helm-git.git
 
-LABEL io.jenkins-infra.tools="helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator"
+LABEL io.jenkins-infra.tools="helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli"
 LABEL io.jenkins-infra.tools.helm.version="${HELM_VERSION}"
 LABEL io.jenkins-infra.tools.helm.plugins="helm-diff,helm-git,helm-secrets"
 LABEL io.jenkins-infra.tools.kubectl.version="${KUBECTL_VERSION}"
@@ -75,4 +75,4 @@ LABEL io.jenkins-infra.tools.yamllint.version="${YAMLLINT_VERSION}"
 LABEL io.jenkins-infra.tools.updatecli.version="${UPDATECLI_VERSION}"
 LABEL io.jenkins-infra.tools.aws-iam-authenticator.version="latest"
 
-ENTRYPOINT ["/usr/local/bin/helmfile"]
+ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:4.11-1-alpine-jdk11
+FROM jenkins/inbound-agent:4.11.2-2-alpine-jdk11
 USER root
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:alpine-jdk11
+FROM jenkins/inbound-agent:4.11-1-alpine-jdk11
 USER root
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
@@ -71,6 +71,8 @@ LABEL io.jenkins-infra.tools.kubectl.version="${KUBECTL_VERSION}"
 LABEL io.jenkins-infra.tools.sops.version="${SOPS_VERSION}"
 LABEL io.jenkins-infra.tools.helmfile.version="${HELMFILE_VERSION}"
 LABEL io.jenkins-infra.tools.aws-cli.version="${AWS_CLI_VERSION}"
+LABEL io.jenkins-infra.tools.yamllint.version="${YAMLLINT_VERSION}"
+LABEL io.jenkins-infra.tools.updatecli.version="${UPDATECLI_VERSION}"
 LABEL io.jenkins-infra.tools.aws-iam-authenticator.version="latest"
 
 ENTRYPOINT ["/usr/local/bin/helmfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.13
-
+FROM jenkins/inbound-agent:alpine-jdk11
+USER root
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 ENV HELM_HOME="/home/helm/.helm"
@@ -40,20 +40,17 @@ RUN wget "https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSI
 
 ## Install aws CLiI tools
 # Please note that only aws cli v1 is supported on alpine - https://github.com/aws/aws-cli/issues/4685
-ARG AWS_CLI_VERSION=1.18
+ARG AWS_CLI_VERSION=1.19
+ARG YAMLLINT_VERSION=1.26
 # hadolint ignore=DL3018
-RUN apk add --no-cache aws-cli=~"${AWS_CLI_VERSION}" less groff \
+RUN apk add --no-cache aws-cli=~"${AWS_CLI_VERSION}" yamllint=~"${YAMLLINT_VERSION}" less groff \
   && aws --version | grep -q "${AWS_CLI_VERSION}"
 ARG AWS_IAM_AUTH_VERSION="1.19.6"
 RUN wget "https://amazon-eks.s3.us-west-2.amazonaws.com/${AWS_IAM_AUTH_VERSION}/2021-01-05/bin/linux/amd64/aws-iam-authenticator" --quiet --output-document=/usr/local/bin/aws-iam-authenticator \
   && chmod a+x /usr/local/bin/aws-iam-authenticator \
   && aws-iam-authenticator version
 
-RUN adduser -D -u 1000 helm
-
-USER helm
-
-WORKDIR /home/helm
+USER jenkins
 
 RUN \
   helm plugin install https://github.com/databus23/helm-diff && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN wget "https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSI
 # Please note that only aws cli v1 is supported on alpine - https://github.com/aws/aws-cli/issues/4685
 ARG AWS_CLI_VERSION=1.19
 ARG YAMLLINT_VERSION=1.26
+ARG UPDATECLI_VERSION=v0.17.2
 # hadolint ignore=DL3018
 RUN apk add --no-cache aws-cli=~"${AWS_CLI_VERSION}" yamllint=~"${YAMLLINT_VERSION}" less groff \
   && aws --version | grep -q "${AWS_CLI_VERSION}"
@@ -49,6 +50,12 @@ ARG AWS_IAM_AUTH_VERSION="1.19.6"
 RUN wget "https://amazon-eks.s3.us-west-2.amazonaws.com/${AWS_IAM_AUTH_VERSION}/2021-01-05/bin/linux/amd64/aws-iam-authenticator" --quiet --output-document=/usr/local/bin/aws-iam-authenticator \
   && chmod a+x /usr/local/bin/aws-iam-authenticator \
   && aws-iam-authenticator version
+
+RUN wget "https://github.com/updatecli/updatecli/releases/download/${UPDATECLI_VERSION}/updatecli_Linux_x86_64.tar.gz" --quiet --output-document=/usr/local/bin/updatecli.tar.gz \
+  && tar zxf /usr/local/bin/updatecli.tar.gz -C /usr/local/bin/ \
+  && chmod a+x /usr/local/bin/updatecli \
+  && updatecli version \
+  && rm /usr/local/bin/updatecli.tar.gz
 
 USER jenkins
 

--- a/cst.yml
+++ b/cst.yml
@@ -5,7 +5,7 @@ metadataTest:
       value: "/home/helm/.helm"
   labels:
     - key: io.jenkins-infra.tools
-      value: "helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator"
+      value: "helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli"
     - key: io.jenkins-infra.tools.helm.version
       value: "3.6.3"
     - key: io.jenkins-infra.tools.helmfile.version
@@ -17,12 +17,12 @@ metadataTest:
     - key: io.jenkins-infra.tools.sops.version
       value: "3.7.1"
     - key: io.jenkins-infra.tools.aws-cli.version
-      value: "1.18"
+      value: "1.19"
     - key: io.jenkins-infra.tools.aws-iam-authenticator.version
       value: "latest"
-  entrypoint: ["/usr/local/bin/helmfile"]
+  entrypoint: ["/usr/local/bin/jenkins-agent"]
   cmd: []
-  workdir: "/home/helm"
+  workdir: "/home/jenkins"
 fileExistenceTests:
   - name: 'Bash'
     path: '/bin/bash'
@@ -72,14 +72,14 @@ fileExistenceTests:
     shouldExist: true
     isExecutableBy: 'any'
   - name: "Default user's home"
-    path: '/home/helm'
+    path: '/home/jenkins'
     shouldExist: true
   - name: "Helm Diff plugin"
-    path: '/home/helm/.local/share/helm/plugins/helm-diff'
+    path: '/home/jenkins/.local/share/helm/plugins/helm-diff'
     shouldExist: true
   - name: "Helm Git plugin"
-    path: '/home/helm/.local/share/helm/plugins/helm-git.git'
+    path: '/home/jenkins/.local/share/helm/plugins/helm-git.git'
     shouldExist: true
   - name: "Helm Secrets plugin"
-    path: '/home/helm/.local/share/helm/plugins/helm-secrets'
+    path: '/home/jenkins/.local/share/helm/plugins/helm-secrets'
     shouldExist: true


### PR DESCRIPTION
jnlp as source: so we don't need to kubectl exec
bump aws-cli: jnlp Alpine version  doesn't contain 1.18 anymore
add yamllint: global image