### PR TITLE
feat: bump updatecli to v0.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN wget "https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSI
 # Please note that only aws cli v1 is supported on alpine - https://github.com/aws/aws-cli/issues/4685
 ARG AWS_CLI_VERSION=1.19
 ARG YAMLLINT_VERSION=1.26
-ARG UPDATECLI_VERSION=v0.17.2
+ARG UPDATECLI_VERSION=v0.18.2
 # hadolint ignore=DL3018
 RUN apk add --no-cache aws-cli=~"${AWS_CLI_VERSION}" yamllint=~"${YAMLLINT_VERSION}" less groff \
   && aws --version | grep -q "${AWS_CLI_VERSION}"

--- a/cst.yml
+++ b/cst.yml
@@ -26,6 +26,8 @@ metadataTest:
       value: "v3.11.0"
     - key: "io.jenkins-infra.tools.helm.plugins.helm-git.version"
       value: "v0.11.1"
+    - key: "io.jenkins-infra.tools.updatecli.version"
+      value: "v0.18.2"
   entrypoint: ["/usr/local/bin/jenkins-agent"]
   cmd: []
   workdir: "/home/jenkins"


### PR DESCRIPTION
Because helm charts resources are broken with 0.18.0/0.18.1.

Ref. https://github.com/updatecli/updatecli/releases/tag/v0.18.2