### PR TITLE
chore(updatecli) Keep track of Jenkins agent version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM jenkins/inbound-agent:4.11.2-2-alpine-jdk11
+ARG JENKINS_AGENT_VERSION=4.11.2-2-alpine-jdk11
+FROM jenkins/inbound-agent:${JENKINS_AGENT_VERSION}
 USER root
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
@@ -67,7 +68,11 @@ RUN \
   helm plugin install https://github.com/jkroepke/helm-secrets --version ${HELM_SECRETS_VERSION} && \
   helm plugin install https://github.com/aslafy-z/helm-git.git --version ${HELM_GIT_VERSION}
 
-LABEL io.jenkins-infra.tools="helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli"
+
+## As per https://docs.docker.com/engine/reference/builder/#scope, ARG need to be repeated for each scope
+ARG JENKINS_AGENT_VERSION=4.11.2-2-alpine-jdk11
+
+LABEL io.jenkins-infra.tools="helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli,jenkins-agent"
 LABEL io.jenkins-infra.tools.helm.version="${HELM_VERSION}"
 LABEL io.jenkins-infra.tools.helm.plugins="helm-diff,helm-git,helm-secrets"
 LABEL io.jenkins-infra.tools.helm.plugins.helm-diff.version="${HELM_DIFF_VERSION}"
@@ -80,5 +85,6 @@ LABEL io.jenkins-infra.tools.aws-cli.version="${AWS_CLI_VERSION}"
 LABEL io.jenkins-infra.tools.yamllint.version="${YAMLLINT_VERSION}"
 LABEL io.jenkins-infra.tools.updatecli.version="${UPDATECLI_VERSION}"
 LABEL io.jenkins-infra.tools.aws-iam-authenticator.version="latest"
+LABEL io.jenkins-infra.tools.jenkins-agent.version="${JENKINS_AGENT_VERSION}"
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/cst.yml
+++ b/cst.yml
@@ -29,7 +29,7 @@ metadataTest:
     - key: "io.jenkins-infra.tools.updatecli.version"
       value: "v0.18.3"
     - key: "io.jenkins-infra.tools.jenkins-agent.version"
-      value: "4.11-1-alpine-jdk11"
+      value: "4.11.2-2-alpine-jdk11"
   entrypoint: ["/usr/local/bin/jenkins-agent"]
   cmd: []
   workdir: "/home/jenkins"

--- a/cst.yml
+++ b/cst.yml
@@ -5,7 +5,7 @@ metadataTest:
       value: "/home/helm/.helm"
   labels:
     - key: io.jenkins-infra.tools
-      value: "helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli"
+      value: "helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli,jenkins-agent"
     - key: io.jenkins-infra.tools.helm.version
       value: "3.6.3"
     - key: io.jenkins-infra.tools.helmfile.version
@@ -28,6 +28,8 @@ metadataTest:
       value: "v0.11.1"
     - key: "io.jenkins-infra.tools.updatecli.version"
       value: "v0.18.3"
+    - key: "io.jenkins-infra.tools.jenkins-agent.version"
+      value: "4.11-1-alpine-jdk11"
   entrypoint: ["/usr/local/bin/jenkins-agent"]
   cmd: []
   workdir: "/home/jenkins"

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -57,7 +57,7 @@ targets:
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[12].value"
-    #scmID: default
+    scmID: default
   updateDockerfileVersion:
     name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
     sourceID: lastVersion
@@ -69,7 +69,7 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JENKINS_AGENT_VERSION"
-    #scmID: default
+    scmID: default
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -57,7 +57,7 @@ targets:
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[12].value"
-    scmID: default
+    #scmID: default
   updateDockerfileVersion:
     name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
     sourceID: lastVersion
@@ -69,7 +69,7 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JENKINS_AGENT_VERSION"
-    scmID: default
+    #scmID: default
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -45,6 +45,13 @@ conditions:
       file: "cst.yml"
       key: "metadataTest.labels[12].key"
       value: io.jenkins-infra.tools.jenkins-agent.version
+  checkDockerImagePublished:
+    name: "Is latest dockerfile docker-inbound-agent image published?"
+    kind: dockerImage
+    sourceID: lastVersion
+    spec:
+      image: "jenkins/inbound-agent" # How can I add the version that is above here ?
+      ## tag comes from the source
 
 
 targets:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -64,7 +64,7 @@ targets:
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[12].value"
-    scmID: default
+    #scmID: default
   updateDockerfileVersion:
     name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
     sourceID: lastVersion
@@ -76,7 +76,7 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JENKINS_AGENT_VERSION"
-    scmID: default
+    #scmID: default
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -65,7 +65,7 @@ targets:
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[12].value"
-    #scmID: default
+    scmID: default
   updateDockerfileVersion:
     name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
     sourceID: lastVersion
@@ -77,7 +77,7 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JENKINS_AGENT_VERSION"
-    #scmID: default
+    scmID: default
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -1,0 +1,83 @@
+---
+title: "Bump jenkins agent version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubRelease
+    name: Get the latest jenkins-agent version
+    spec:
+      owner: "jenkinsci"
+      repository: "docker-inbound-agent"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+      transformers:
+        - addSuffix: "-alpine-jdk11"
+
+conditions:
+  testDockerfile:
+    name: "Does the Dockerfile have an ARG instruction which key is JENKINS_AGENT_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JENKINS_AGENT_VERSION"
+  testTestHarness:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.jenkins-agent.version?"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[12].key"
+      value: io.jenkins-infra.tools.jenkins-agent.version
+
+
+targets:
+  updateTestVersion:
+    name: "Update the test harness"
+    sourceID: lastVersion
+    kind: yaml
+    transformers:
+      - addSuffix: "-alpine-jdk11"
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[12].value"
+    scmID: default
+  updateDockerfileVersion:
+    name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
+    sourceID: lastVersion
+    kind: dockerfile
+    transformers:
+      - addSuffix: "-alpine-jdk11"
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JENKINS_AGENT_VERSION"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateTestVersion
+      - updateDockerfileVersion
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -51,6 +51,7 @@ conditions:
     sourceID: lastVersion
     spec:
       image: "jenkins/inbound-agent" # How can I add the version that is above here ?
+      architecture: "amd64"
       ## tag comes from the source
 
 


### PR DESCRIPTION
adding the updatecli versioning with an ARG and updating the CST file appropriately. 
@dduportal  I wonder if it need a check on the existence of the docker image in the hub somewhere within the process.

fix : #42 