### PR TITLE
Feat: add tools required for infra-reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,14 @@ RUN wget "https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSI
   && chmod +x /usr/local/bin/doctl \
   && doctl version | grep -q "${DOCTL_VERSION}"
 
+ARG RUBY_VERSION=3.0
+## Always use the latest Gem and package versions
+# hadolint ignore=DL3028,DL3018
+RUN apk add --no-cache --virtual .build-deps build-base openssl-dev ruby-dev \
+  && apk add --no-cache openssl ruby=~"${RUBY_VERSION}" \
+  && gem install --no-document graphql-client httparty jwt time openssl base64 \
+  && apk del --purge .build-deps
+
 USER jenkins
 
 ARG HELM_DIFF_VERSION=v3.4.2
@@ -84,7 +92,7 @@ RUN \
 ## As per https://docs.docker.com/engine/reference/builder/#scope, ARG need to be repeated for each scope
 ARG JENKINS_AGENT_VERSION=4.11.2-4-alpine-jdk11
 
-LABEL io.jenkins-infra.tools="helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli,jenkins-agent,doctl"
+LABEL io.jenkins-infra.tools="helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli,jenkins-agent,doctl,jq,yq,ruby"
 LABEL io.jenkins-infra.tools.helm.version="${HELM_VERSION}"
 LABEL io.jenkins-infra.tools.helm.plugins="helm-diff,helm-git,helm-secrets"
 LABEL io.jenkins-infra.tools.helm.plugins.helm-diff.version="${HELM_DIFF_VERSION}"
@@ -99,5 +107,6 @@ LABEL io.jenkins-infra.tools.updatecli.version="${UPDATECLI_VERSION}"
 LABEL io.jenkins-infra.tools.aws-iam-authenticator.version="latest"
 LABEL io.jenkins-infra.tools.jenkins-agent.version="${JENKINS_AGENT_VERSION}"
 LABEL io.jenkins-infra.tools.doctl.version="${DOCTL_VERSION}"
+LABEL io.jenkins-infra.tools.ruby.version="${RUBY_VERSION}"
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 ENV HELM_HOME="/home/helm/.helm"
 
+## Always use the latest Alpine packages
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
   ca-certificates \
@@ -12,9 +13,11 @@ RUN apk add --no-cache \
   bash \
   git \
   gnupg \
+  jq \
   tar \
   unzip \
-  wget
+  wget \
+  yq
 
 ARG HELM_VERSION=3.6.3
 RUN wget "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" --quiet --output-document=/tmp/helm.tgz \

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,7 @@
-parallelDockerUpdatecli([imageName: 'helmfile', rebuildImageOnPeriodicJob: false, containerMemory: '768Mi'])
+@Library('pipeline-library@pull/311/head') _
+
+ buildDockerAndPublishImage('helmfile', [
+  automaticSemanticVersioning: true,
+  gitCredentials: 'github-app-infra',
+  useContainer: false,
+])

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,6 +1,4 @@
-@Library('pipeline-library@pull/311/head') _
-
- buildDockerAndPublishImage('helmfile', [
+buildDockerAndPublishImage('helmfile', [
   automaticSemanticVersioning: true,
   gitCredentials: 'github-app-infra',
   useContainer: false,

--- a/cst.yml
+++ b/cst.yml
@@ -5,7 +5,7 @@ metadataTest:
       value: "/home/helm/.helm"
   labels:
     - key: io.jenkins-infra.tools
-      value: "helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli,jenkins-agent,doctl"
+      value: "helm,kubectl,helmfile,sops,aws-cli,aws-iam-authenticator,yamllint,updatecli,jenkins-agent,doctl,jq,yq,ruby"
     - key: io.jenkins-infra.tools.helm.version
       value: "3.6.3"
     - key: io.jenkins-infra.tools.helmfile.version
@@ -32,6 +32,8 @@ metadataTest:
       value: "4.11.2-4-alpine-jdk11"
     - key: "io.jenkins-infra.tools.doctl.version"
       value: "1.70.0"
+    - key: "io.jenkins-infra.tools.ruby.version"
+      value: "3.0"
   entrypoint: ["/usr/local/bin/jenkins-agent"]
   cmd: []
   workdir: "/home/jenkins"


### PR DESCRIPTION
As part of https://github.com/jenkins-infra/helpdesk/issues/2789, this PR ensures that the required tools to allow running the scripts of https://github.com/jenkins-infra/infra-reports are present.

It adds the following elements:

- `jq` and `yq` in their latest version available in the package manager of the base image (Alpine 3.15 when writing these lines)
- `ruby` in the latest 3.0.x version available in the package manager of the base image (Alpine 3.15 when writing these lines). 
  - No updatecli for this as it's a bit hard to retrieve the Alpine package version for this version. No worries though: when the base image will be upgraded to a more recent version of Alpine that would bump Ruby's minor (or major) version, then the build would fail and would require attention.
- Latest versions of the rubygems for http and graphql are installed. 

