### PR TITLE
fix: ensure that SOPS for Intel AMD64 is used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN wget "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_V
 
 # Install sops
 ARG SOPS_VERSION=3.7.2
-RUN wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux" --quiet --output-document=/usr/local/bin/sops \
+RUN wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.amd64" --quiet --output-document=/usr/local/bin/sops \
   && chmod +x /usr/local/bin/sops \
   && sops --version | grep -q "${SOPS_VERSION}"
 


### PR DESCRIPTION
In https://github.com/jenkins-infra/kubernetes-management/pull/2091, it seems that the sops binary of the release 3.7.2 was an arm version (since its only prefix is `.linux` there might have been an issue).

This PR ensures that AMD64 binary is used.