### PR TITLE
chore(updatecli): upgrade to kubectl 1.21.x

### DIFF
--- a/updatecli/updatecli.d/kubectl.yml
+++ b/updatecli/updatecli.d/kubectl.yml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionFilter:
         kind: regex
-        pattern: "^kubernetes-1.20.(\\d*)$"
+        pattern: "^kubernetes-1.21.(\\d*)$"
 
 conditions:
   dockerfileArgKubectlVersion:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2866 this PR should allow updatecli to upgrade kubernetes to version 1.21.x 