### PR TITLE
chore(kubectl): upgrade kubectl via updatecli to 1.22

### DIFF
--- a/updatecli/updatecli.d/kubectl.yml
+++ b/updatecli/updatecli.d/kubectl.yml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.21.(\\d*)$"
+        pattern: "^kubernetes-1.22.(\\d*)$"
 
 conditions:
   dockerfileArgKubectlVersion:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2930
upgrading kubectl by updatecli