### PR TITLE
feat(aws-cli) Bump from 1.19 native package to 1.25.4 pip package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,10 @@ RUN apk add --no-cache \
   bash \
   git \
   gnupg \
+  groff \
   jq \
+  less \
+  py-pip \
   tar \
   unzip \
   wget \
@@ -42,12 +45,14 @@ RUN wget "https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSI
   && chmod +x /usr/local/bin/helmfile \
   && helmfile --version | grep -q "${HELMFILE_VERSION}"
 
+ARG YAMLLINT_VERSION=1.26
+RUN apk add --no-cache yamllint=~"${YAMLLINT_VERSION}" \
+  && yamllint --version | grep -q "${YAMLLINT_VERSION}"
+
 ## Install AWS CLI tools
 # Please note that only aws cli v1 is supported on alpine - https://github.com/aws/aws-cli/issues/4685
-ARG AWS_CLI_VERSION=1.19
-ARG YAMLLINT_VERSION=1.26
-# hadolint ignore=DL3018
-RUN apk add --no-cache aws-cli=~"${AWS_CLI_VERSION}" yamllint=~"${YAMLLINT_VERSION}" less groff \
+ARG AWS_CLI_VERSION=1.25.4
+RUN python3 -m pip install --no-cache-dir awscli=="${AWS_CLI_VERSION}" \
   && aws --version | grep -q "${AWS_CLI_VERSION}"
 ARG AWS_IAM_AUTH_VERSION="1.19.6"
 RUN wget "https://amazon-eks.s3.us-west-2.amazonaws.com/${AWS_IAM_AUTH_VERSION}/2021-01-05/bin/linux/amd64/aws-iam-authenticator" --quiet --output-document=/usr/local/bin/aws-iam-authenticator \

--- a/cst.yml
+++ b/cst.yml
@@ -17,7 +17,7 @@ metadataTest:
     - key: io.jenkins-infra.tools.sops.version
       value: "3.7.3"
     - key: io.jenkins-infra.tools.aws-cli.version
-      value: "1.19"
+      value: "1.25.4"
     - key: io.jenkins-infra.tools.aws-iam-authenticator.version
       value: "latest"
     - key: "io.jenkins-infra.tools.helm.plugins.helm-diff.version"

--- a/updatecli/updatecli.d/awscli.yml
+++ b/updatecli/updatecli.d/awscli.yml
@@ -1,0 +1,79 @@
+---
+title: "Bump awscli version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getAwscliVersion:
+    kind: githubrelease
+    name: Get the latest Awscli version
+    spec:
+      owner: "aws"
+      repository: "aws-cli"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        ## Latest stable 1.x.y version
+        pattern: '1\.(\d*)\.(\d*)$'
+
+conditions:
+  testDockerfileArgAwscliVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is AWS_CLI_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "AWS_CLI_VERSION"
+  testCstAwscliVersion:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.aws-cli.version?"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[6].key"
+      value: io.jenkins-infra.tools.aws-cli.version
+
+targets:
+  updateCstVersion:
+    name: "Update the label io.jenkins-infra.tools.aws-cli.version in the test harness"
+    sourceid: getAwscliVersion
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[6].value"
+    scmid: default
+  updateDockerfileArgVersion:
+    name: "Update the value of ARG AWS_CLI_VERSION in the Dockerfile"
+    sourceid: getAwscliVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "AWS_CLI_VERSION"
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - updateCstVersion
+      - updateDockerfileArgVersion
+    spec:
+      labels:
+        - dependencies
+        - awscli


### PR DESCRIPTION
Context: https://github.com/jenkins-infra/kubernetes-management/pull/2403

=> with the May upgrade of the kubernetes go client (latest patches for any kubectl 1.x line, but also helm 3.9.0), the system in charge of delegating authentication to another command line (in this case `aws eks get-token <...>` as specified in our `kubeconfig`) had an API model upgrade: it was changed from `v1alpha1` to `v1beta1`.

Changing the API version annotation in the `kubeconfig` is not enough: the external CLI, such as `aws` CLI must be recent.

Problem: we are pinned on the 1.19 line when using the alpine package, because we rely on the 3.15 line from the parent jenkins inbound-agent image.

This PR introduces the following changes:

- Changes the installation method of the `aws-cli` from "native Alpine package" to "Python Pip package" to make sure that our AWS CLI version is controlled without depending on the parent image
- Bump the `aws` CLI version from 1.19.105 to 1.25.4 (latest today, published 20 hours ago), which supports the `v1beta1` authentication
- Add an updatecli manifest which tracks the AWS CLI version, pinned on the "v1" line though (as the v2 does not work on Alpine).