### PR TITLE
fix: switch to new helmfile github organisation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sop
 # Install helmfile
 ARG HELMFILE_VERSION=0.145.0
 RUN wget "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_arm64.tar.gz" --quiet --output-document=/tmp/helmfile.tgz \
-  && tar zxf /tmp/helmfile.tgz helmfile -C /usr/local/bin/ \
+  && && tar --gzip --verbose --extract --file=/tmp/helmfile.tgz --directory=/usr/local/bin helmfile \
   && rm /tmp/* \
   && helmfile --version | grep -q "${HELMFILE_VERSION}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sop
 
 # Install helmfile
 ARG HELMFILE_VERSION=0.144.0
-RUN wget "https://github.com/roboll/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_linux_amd64" --quiet --output-document=/usr/local/bin/helmfile \
+RUN wget "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_linux_amd64" --quiet --output-document=/usr/local/bin/helmfile \
   && chmod +x /usr/local/bin/helmfile \
   && helmfile --version | grep -q "${HELMFILE_VERSION}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sop
 # Install helmfile
 ARG HELMFILE_VERSION=0.145.0
 RUN wget "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_arm64.tar.gz" --quiet --output-document=/tmp/helmfile.tgz \
-  && tar zxf /tmp/helmfile.tgz --strip-components 1 -C /usr/local/bin/ \
+  && tar zxf /tmp/helmfile.tgz helmfile -C /usr/local/bin/ \
   && rm /tmp/* \
   && helmfile --version | grep -q "${HELMFILE_VERSION}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sop
 # Install helmfile
 ARG HELMFILE_VERSION=0.145.0
 RUN wget "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_arm64.tar.gz" --quiet --output-document=/tmp/helmfile.tgz \
-  && tar --gzip --verbose --extract --file=/tmp/helmfile.tgz --directory=/usr/local/bin helmfile \
+  && tar --extract --gzip --verbose --file=/tmp/helmfile.tgz --directory=/usr/local/bin helmfile \
   && rm /tmp/* \
   && helmfile --version | grep -q "${HELMFILE_VERSION}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ ARG HELMFILE_VERSION=0.145.0
 RUN wget "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_arm64.tar.gz" --quiet --output-document=/tmp/helmfile.tgz \
   && tar zxf /tmp/helmfile.tgz --strip-components 1 -C /usr/local/bin/ \
   && rm /tmp/* \
-  && chmod +x /usr/local/bin/helmfile \
   && helmfile --version | grep -q "${HELMFILE_VERSION}"
 
 ARG YAMLLINT_VERSION=1.26

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sop
 # Install helmfile
 ARG HELMFILE_VERSION=0.145.0
 RUN wget "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_arm64.tar.gz" --quiet --output-document=/tmp/helmfile.tgz \
-  && && tar --gzip --verbose --extract --file=/tmp/helmfile.tgz --directory=/usr/local/bin helmfile \
+  && tar --gzip --verbose --extract --file=/tmp/helmfile.tgz --directory=/usr/local/bin helmfile \
   && rm /tmp/* \
   && helmfile --version | grep -q "${HELMFILE_VERSION}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,10 @@ RUN wget "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sop
   && sops --version | grep -q "${SOPS_VERSION}"
 
 # Install helmfile
-ARG HELMFILE_VERSION=0.144.0
-RUN wget "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_linux_amd64" --quiet --output-document=/usr/local/bin/helmfile \
+ARG HELMFILE_VERSION=0.145.0
+RUN wget "https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_arm64.tar.gz" --quiet --output-document=/tmp/helmfile.tgz \
+  && tar zxf /tmp/helmfile.tgz --strip-components 1 -C /usr/local/bin/ \
+  && rm /tmp/* \
   && chmod +x /usr/local/bin/helmfile \
   && helmfile --version | grep -q "${HELMFILE_VERSION}"
 

--- a/cst.yml
+++ b/cst.yml
@@ -9,7 +9,7 @@ metadataTest:
     - key: io.jenkins-infra.tools.helm.version
       value: "3.9.0"
     - key: io.jenkins-infra.tools.helmfile.version
-      value: "0.144.0"
+      value: "0.145.0"
     - key: "io.jenkins-infra.tools.helm.plugins"
       value: "helm-diff,helm-git,helm-secrets"
     - key: io.jenkins-infra.tools.kubectl.version

--- a/updatecli/updatecli.d/helmfile.yml
+++ b/updatecli/updatecli.d/helmfile.yml
@@ -18,7 +18,7 @@ sources:
     kind: githubrelease
     name: Get the latest helmfile version
     spec:
-      owner: "roboll"
+      owner: "helmfile"
       repository: "helmfile"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"


### PR DESCRIPTION
Fixes #106

First release in helmfile new organisation published yesterday: https://github.com/helmfile/helmfile/releases/tag/v0.145.0