### PR TITLE
chore(updatecli) remove 'v' prefix from semantic versions when uneeded (doctl, helm, helmfile, sops)

### DIFF
--- a/updatecli/updatecli.d/doctl.yml
+++ b/updatecli/updatecli.d/doctl.yml
@@ -24,6 +24,8 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: semver
+    transformers:
+      - trimprefix: v
 
 conditions:
   dockerfileArgDoctlVersion:

--- a/updatecli/updatecli.d/helm.yml
+++ b/updatecli/updatecli.d/helm.yml
@@ -24,6 +24,8 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: semver
+    transformers:
+      - trimprefix: v
 
 conditions:
   dockerfileArgHelmVersion:

--- a/updatecli/updatecli.d/helmfile.yml
+++ b/updatecli/updatecli.d/helmfile.yml
@@ -24,7 +24,8 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: semver
-        pattern: "~0"
+    transformers:
+      - trimprefix: v
 
 conditions:
   dockerfileArgHelmfileVersion:

--- a/updatecli/updatecli.d/sops.yml
+++ b/updatecli/updatecli.d/sops.yml
@@ -24,7 +24,8 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: semver
-        pattern: "~3"
+    transformers:
+      - trimprefix: v
 
 conditions:
   dockerfileArgSopsVersion:


### PR DESCRIPTION
Closes #190
Closes #191
Closes #192
Closes #193

(Four PR fails when building because of the `v` prefix)