### PR TITLE
chore(updatecli) track `kubectl` 1.24.x line

### DIFF
--- a/updatecli/updatecli.d/kubectl.yml
+++ b/updatecli/updatecli.d/kubectl.yml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.23.(\\d*)$"
+        pattern: "^kubernetes-1.24.(\\d*)$"
 
 conditions:
   dockerfileArgKubectlVersion:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3387

Once merged, this PR will open another (automatic) Updatecli's PR with the `kubectl 1.24.x` bump.