### PR TITLE
chore(updatecli) track `kubectl` 1.25.x (instead of 1.24.x)

### DIFF
--- a/updatecli/updatecli.d/kubectl.yml
+++ b/updatecli/updatecli.d/kubectl.yml
@@ -26,7 +26,7 @@ sources:
       username: "{{ .github.username }}"
       versionfilter:
         kind: regex
-        pattern: "^kubernetes-1.24.(\\d*)$"
+        pattern: "^kubernetes-1.25.(\\d*)$"
 
 conditions:
   dockerfileArgKubectlVersion:


### PR DESCRIPTION
Needs #299 

Related to https://github.com/jenkins-infra/helpdesk/issues/3582