### PR TITLE
feat: bump updatecli to 0.54.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN python3 -m pip install --no-cache-dir awscli=="${AWS_CLI_VERSION}" \
   && aws --version | grep -q "${AWS_CLI_VERSION}"
 
 # Install updatecli
-ARG UPDATECLI_VERSION=v0.52.0
+ARG UPDATECLI_VERSION=v0.54.0
 RUN wget "https://github.com/updatecli/updatecli/releases/download/${UPDATECLI_VERSION}/updatecli_Linux_x86_64.tar.gz" --quiet --output-document=/usr/local/bin/updatecli.tar.gz \
   && tar zxf /usr/local/bin/updatecli.tar.gz -C /usr/local/bin/ \
   && chmod a+x /usr/local/bin/updatecli \

--- a/cst.yml
+++ b/cst.yml
@@ -25,7 +25,7 @@ metadataTest:
     - key: "io.jenkins-infra.tools.helm.plugins.helm-git.version"
       value: "v0.15.1"
     - key: "io.jenkins-infra.tools.updatecli.version"
-      value: "v0.52.0"
+      value: v0.54.0
     - key: "io.jenkins-infra.tools.jenkins-agent.version"
       value: "3107.v665000b_51092-15-alpine-jdk11"
     - key: "io.jenkins-infra.tools.doctl.version"


### PR DESCRIPTION
The updatecli uses 0.52.0 which suffers of a bug fixed in 0.53.0.

This PR manually bump it to unlock all the updates without the bug.